### PR TITLE
Fix protobuf classes unmangled

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -29,6 +29,12 @@
 # Keep termlib classes — native JNI renderer accesses fields by name
 -keep class org.connectbot.terminal.** { *; }
 
+# Keep mosh transport + generated protobuf classes.
+# The pure-Kotlin transport reflects on protobuf field names like `width_`.
+# If R8 renames those fields, Mosh connects but never establishes a usable
+# terminal session in release builds.
+-keep class sh.haven.mosh.** { *; }
+
 # Keep smbj (reflection-based protocol handling)
 -keep class com.hierynomus.** { *; }
 -keep class net.engio.** { *; }


### PR DESCRIPTION
Release builds currently let R8 rename parts of the Mosh transport/protobuf stack that are accessed by name at runtime.

In practice, that can leave Mosh apparently connecting in release builds but never reaching a usable terminal session.

This change adds an explicit keep rule for `sh.haven.mosh.**` so the Mosh transport and its generated protobuf classes keep the names they rely on.

## Why

We already keep `GeneratedMessageLite` subclasses in general, but the Mosh transport still depends on stable names in its own package.

Keeping the Mosh package as a unit is the smallest fix that makes release builds behave like debug builds again.

