### PR TITLE
Move app navigation to the side in landscape

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material3.window.size)
     implementation(libs.compose.material.icons)
     implementation(libs.compose.ui.tooling.preview)
 

--- a/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
+++ b/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
@@ -1,5 +1,6 @@
 package sh.haven.app.navigation
 
+import android.content.res.Configuration
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
@@ -8,6 +9,8 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.ui.res.stringResource
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,6 +21,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
@@ -43,6 +48,7 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.CoroutineScope
@@ -166,127 +172,14 @@ fun HavenNavHost(
     val navItemWidths = remember { mutableStateMapOf<Int, Float>() }
     val haptic = LocalHapticFeedback.current
 
-    Scaffold(
-        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(WindowInsets.ime),
-        bottomBar = {
-            if (!desktopFullscreen) {
-                NavigationBar {
-                    val currentScreen = screens.getOrNull(pagerState.currentPage)
-                    navScreens.forEachIndexed { index, screen ->
-                        val isDragged = index == navDragIndex
-                        NavigationBarItem(
-                            icon = { Icon(screen.icon, contentDescription = stringResource(screen.labelRes)) },
-                            label = {
-                                // maxLines = 1 + ellipsis guards against any locale whose
-                                // nav label is too long for the tab slot on narrow devices
-                                // (e.g. Samsung S23 portrait with 5 tabs). Previously the
-                                // label could wrap to two lines and distort the whole bar
-                                // height — see #78.
-                                Text(
-                                    text = stringResource(screen.labelRes),
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    softWrap = false,
-                                )
-                            },
-                            selected = screen == currentScreen,
-                            onClick = {
-                                if (navDragIndex < 0) {
-                                    val pageIndex = screens.indexOf(screen)
-                                    if (pageIndex >= 0) coroutineScope.launch {
-                                        // Use instant scroll to avoid double-jump through
-                                        // intermediate pages during animated scroll
-                                        pagerState.scrollToPage(pageIndex)
-                                    }
-                                }
-                            },
-                            modifier = Modifier
-                                .onGloballyPositioned { coords ->
-                                    navItemLefts[index] = coords.positionInParent().x
-                                    navItemWidths[index] = coords.size.width.toFloat()
-                                }
-                                .then(
-                                    if (isDragged) {
-                                        Modifier
-                                            .zIndex(1f)
-                                            .offset { IntOffset(navDragOffset.roundToInt(), 0) }
-                                    } else {
-                                        Modifier
-                                    },
-                                )
-                                .pointerInput(Unit) {
-                                    detectDragGesturesAfterLongPress(
-                                        onDragStart = {
-                                            navDragIndex = index
-                                            navDragOffset = 0f
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        },
-                                        onDrag = { change, offset ->
-                                            change.consume()
-                                            navDragOffset += offset.x
-                                            val di = navDragIndex
-                                            if (di < 0) return@detectDragGesturesAfterLongPress
-                                            val myLeft = navItemLefts[di] ?: return@detectDragGesturesAfterLongPress
-                                            val myW = navItemWidths[di] ?: return@detectDragGesturesAfterLongPress
-                                            val myCenter = myLeft + myW / 2 + navDragOffset
-                                            // Swap right
-                                            if (di < navScreens.size - 1) {
-                                                val nextLeft = navItemLefts[di + 1] ?: 0f
-                                                val nextW = navItemWidths[di + 1] ?: 0f
-                                                if (myCenter > nextLeft + nextW / 2) {
-                                                    val item = navScreens.removeAt(di)
-                                                    navScreens.add(di + 1, item)
-                                                    navDragOffset -= nextW
-                                                    navDragIndex = di + 1
-                                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                                                }
-                                            }
-                                            // Swap left
-                                            if (di > 0) {
-                                                val prevLeft = navItemLefts[di - 1] ?: 0f
-                                                val prevW = navItemWidths[di - 1] ?: 0f
-                                                if (myCenter < prevLeft + prevW / 2) {
-                                                    val item = navScreens.removeAt(di)
-                                                    navScreens.add(di - 1, item)
-                                                    navDragOffset += prevW
-                                                    navDragIndex = di - 1
-                                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                                                }
-                                            }
-                                        },
-                                        onDragEnd = {
-                                            navDragIndex = -1
-                                            navDragOffset = 0f
-                                            coroutineScope.launch {
-                                                preferencesRepository.setScreenOrder(
-                                                    navScreens.map { it.route },
-                                                )
-                                            }
-                                        },
-                                        onDragCancel = {
-                                            navDragIndex = -1
-                                            navDragOffset = 0f
-                                            coroutineScope.launch {
-                                                preferencesRepository.setScreenOrder(
-                                                    navScreens.map { it.route },
-                                                )
-                                            }
-                                        },
-                                    )
-                                },
-                        )
-                    }
-                }
-            }
-        }
-    ) { innerPadding ->
+    val useSideNavigation =
+        LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    val pagerContent: @Composable (Modifier) -> Unit = { modifier ->
         HorizontalPager(
             state = pagerState,
             userScrollEnabled = !desktopFullscreen && !desktopConnected && !terminalSelectionActive,
-            modifier = Modifier
-                .padding(innerPadding)
-                .consumeWindowInsets(innerPadding)
-                .imePadding(),
+            modifier = modifier,
         ) { page ->
             when (screens[page]) {
                 Screen.Connections -> ConnectionsScreen(
@@ -439,6 +332,156 @@ fun HavenNavHost(
                     if (openToolbarConfig) openToolbarConfig = false
                 }
             }
+        }
+    }
+
+    Scaffold(
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(WindowInsets.ime),
+        bottomBar = {
+            if (!desktopFullscreen && !useSideNavigation) {
+                NavigationBar {
+                    val currentScreen = screens.getOrNull(pagerState.currentPage)
+                    navScreens.forEachIndexed { index, screen ->
+                        val isDragged = index == navDragIndex
+                        NavigationBarItem(
+                            icon = { Icon(screen.icon, contentDescription = stringResource(screen.labelRes)) },
+                            label = {
+                                Text(
+                                    text = stringResource(screen.labelRes),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    softWrap = false,
+                                )
+                            },
+                            selected = screen == currentScreen,
+                            onClick = {
+                                if (navDragIndex < 0) {
+                                    val pageIndex = screens.indexOf(screen)
+                                    if (pageIndex >= 0) coroutineScope.launch {
+                                        pagerState.scrollToPage(pageIndex)
+                                    }
+                                }
+                            },
+                            modifier = Modifier
+                                .onGloballyPositioned { coords ->
+                                    navItemLefts[index] = coords.positionInParent().x
+                                    navItemWidths[index] = coords.size.width.toFloat()
+                                }
+                                .then(
+                                    if (isDragged) {
+                                        Modifier
+                                            .zIndex(1f)
+                                            .offset { IntOffset(navDragOffset.roundToInt(), 0) }
+                                    } else {
+                                        Modifier
+                                    },
+                                )
+                                .pointerInput(Unit) {
+                                    detectDragGesturesAfterLongPress(
+                                        onDragStart = {
+                                            navDragIndex = index
+                                            navDragOffset = 0f
+                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        },
+                                        onDrag = { change, offset ->
+                                            change.consume()
+                                            navDragOffset += offset.x
+                                            val di = navDragIndex
+                                            if (di < 0) return@detectDragGesturesAfterLongPress
+                                            val myLeft = navItemLefts[di] ?: return@detectDragGesturesAfterLongPress
+                                            val myW = navItemWidths[di] ?: return@detectDragGesturesAfterLongPress
+                                            val myCenter = myLeft + myW / 2 + navDragOffset
+                                            if (di < navScreens.size - 1) {
+                                                val nextLeft = navItemLefts[di + 1] ?: 0f
+                                                val nextW = navItemWidths[di + 1] ?: 0f
+                                                if (myCenter > nextLeft + nextW / 2) {
+                                                    val item = navScreens.removeAt(di)
+                                                    navScreens.add(di + 1, item)
+                                                    navDragOffset -= nextW
+                                                    navDragIndex = di + 1
+                                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                                }
+                                            }
+                                            if (di > 0) {
+                                                val prevLeft = navItemLefts[di - 1] ?: 0f
+                                                val prevW = navItemWidths[di - 1] ?: 0f
+                                                if (myCenter < prevLeft + prevW / 2) {
+                                                    val item = navScreens.removeAt(di)
+                                                    navScreens.add(di - 1, item)
+                                                    navDragOffset += prevW
+                                                    navDragIndex = di - 1
+                                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                                }
+                                            }
+                                        },
+                                        onDragEnd = {
+                                            navDragIndex = -1
+                                            navDragOffset = 0f
+                                            coroutineScope.launch {
+                                                preferencesRepository.setScreenOrder(navScreens.map { it.route })
+                                            }
+                                        },
+                                        onDragCancel = {
+                                            navDragIndex = -1
+                                            navDragOffset = 0f
+                                            coroutineScope.launch {
+                                                preferencesRepository.setScreenOrder(navScreens.map { it.route })
+                                            }
+                                        },
+                                    )
+                                },
+                        )
+                    }
+                }
+            }
+        },
+    ) { innerPadding ->
+        if (useSideNavigation) {
+            Row(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .consumeWindowInsets(innerPadding)
+                    .imePadding(),
+            ) {
+                if (!desktopFullscreen) {
+                    NavigationRail(
+                        modifier = Modifier.fillMaxHeight(),
+                    ) {
+                        val currentScreen = screens.getOrNull(pagerState.currentPage)
+                        navScreens.forEach { screen ->
+                            val pageIndex = screens.indexOf(screen)
+                            if (pageIndex >= 0) {
+                                NavigationRailItem(
+                                    icon = { Icon(screen.icon, contentDescription = stringResource(screen.labelRes)) },
+                                    label = {
+                                        Text(
+                                            text = stringResource(screen.labelRes),
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                            softWrap = false,
+                                        )
+                                    },
+                                    alwaysShowLabel = false,
+                                    selected = screen == currentScreen,
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            pagerState.scrollToPage(pageIndex)
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+                pagerContent(Modifier.weight(1f))
+            }
+        } else {
+            pagerContent(
+                Modifier
+                    .padding(innerPadding)
+                    .consumeWindowInsets(innerPadding)
+                    .imePadding(),
+            )
         }
     }
 }

--- a/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
+++ b/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
@@ -1,6 +1,5 @@
 package sh.haven.app.navigation
 
-import android.content.res.Configuration
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
@@ -47,8 +46,11 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.zIndex
 import kotlinx.coroutines.CoroutineScope
@@ -65,6 +67,7 @@ import sh.haven.feature.terminal.TerminalScreen
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun HavenNavHost(
     preferencesRepository: UserPreferencesRepository,
@@ -172,8 +175,13 @@ fun HavenNavHost(
     val navItemWidths = remember { mutableStateMapOf<Int, Float>() }
     val haptic = LocalHapticFeedback.current
 
+    // Use WindowSizeClass (width >= Medium, i.e. >= 600dp) as the Material3-recommended
+    // signal for switching to a side rail.  This avoids triggering the rail on narrow
+    // landscape phones where it would eat more width than it saves, while also opting
+    // wide-enough portrait tablets into the rail.
+    val windowSizeClass = calculateWindowSizeClass(LocalContext.current as android.app.Activity)
     val useSideNavigation =
-        LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+        windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium
 
     val pagerContent: @Composable (Modifier) -> Unit = { modifier ->
         HorizontalPager(

--- a/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
+++ b/app/src/main/kotlin/sh/haven/app/navigation/HavenNavHost.kt
@@ -346,6 +346,11 @@ fun HavenNavHost(
                         NavigationBarItem(
                             icon = { Icon(screen.icon, contentDescription = stringResource(screen.labelRes)) },
                             label = {
+                                // maxLines = 1 + ellipsis guards against any locale whose
+                                // nav label is too long for the tab slot on narrow devices
+                                // (e.g. Samsung S23 portrait with 5 tabs). Previously the
+                                // label could wrap to two lines and distort the whole bar
+                                // height — see #78.
                                 Text(
                                     text = stringResource(screen.labelRes),
                                     maxLines = 1,
@@ -358,6 +363,8 @@ fun HavenNavHost(
                                 if (navDragIndex < 0) {
                                     val pageIndex = screens.indexOf(screen)
                                     if (pageIndex >= 0) coroutineScope.launch {
+                                        // Use instant scroll to avoid double-jump through
+                                        // intermediate pages during animated scroll
                                         pagerState.scrollToPage(pageIndex)
                                     }
                                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-material3-window-size = { group = "androidx.compose.material3", name = "material3-window-size-class" }
 compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 # AndroidX


### PR DESCRIPTION
## Summary

This switches the main app navigation from a bottom bar to a side rail when the device is in landscape orientation.

Behavior after this change:

- portrait keeps the existing bottom navigation bar
- landscape uses a `NavigationRail`
- desktop fullscreen still hides navigation entirely
- the existing pager content and screen routing stay the same
- bottom-nav drag-to-reorder behavior is preserved in portrait mode

The landscape rail uses the current screen order, so it stays consistent with the user’s saved navigation order.

## Why

In landscape, vertical space is more valuable and horizontal space is easier to spare.

Moving navigation to the side gives terminal/desktop/content screens more usable height without changing the portrait experience.
