### PR TITLE
Enable Dependabot for GitHub Actions, Gradle, Cargo, and Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: cargo
+    directory: /rdp-kotlin/rust
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: gomod
+    directory: /rclone-android/go
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/app/src/main/kotlin/sh/haven/app/HavenApp.kt
+++ b/app/src/main/kotlin/sh/haven/app/HavenApp.kt
@@ -1,8 +1,6 @@
 package sh.haven.app
 
 import android.app.Application
-import com.chaquo.python.Python
-import com.chaquo.python.android.AndroidPlatform
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -23,9 +21,6 @@ class HavenApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        if (!Python.isStarted()) {
-            Python.start(AndroidPlatform(this))
-        }
         // Register Shizuku binder listeners early so the async callback
         // has time to fire before any UI checks isShizukuAvailable().
         sh.haven.core.local.WaylandSocketHelper.initShizukuListeners()

--- a/app/src/main/kotlin/sh/haven/app/agent/McpServer.kt
+++ b/app/src/main/kotlin/sh/haven/app/agent/McpServer.kt
@@ -15,8 +15,10 @@ import org.json.JSONArray
 import org.json.JSONObject
 import sh.haven.core.data.db.entities.AgentAuditEvent
 import sh.haven.core.data.repository.ConnectionRepository
+import sh.haven.core.ffmpeg.HlsStreamServer
 import sh.haven.core.rclone.RcloneClient
 import sh.haven.core.ssh.SshSessionManager
+import sh.haven.feature.sftp.SftpStreamServer
 import java.io.BufferedReader
 import java.io.Closeable
 import java.io.IOException
@@ -71,6 +73,8 @@ class McpServer @Inject constructor(
     private val connectionRepository: ConnectionRepository,
     private val sshSessionManager: SshSessionManager,
     private val rcloneClient: RcloneClient,
+    private val sftpStreamServer: SftpStreamServer,
+    private val hlsStreamServer: HlsStreamServer,
     private val auditRecorder: AgentAuditRecorder,
 ) : Closeable {
 
@@ -134,6 +138,8 @@ class McpServer @Inject constructor(
         connectionRepository = connectionRepository,
         sshSessionManager = sshSessionManager,
         rcloneClient = rcloneClient,
+        sftpStreamServer = sftpStreamServer,
+        hlsStreamServer = hlsStreamServer,
     )
 
     /**

--- a/app/src/main/kotlin/sh/haven/app/agent/McpTools.kt
+++ b/app/src/main/kotlin/sh/haven/app/agent/McpTools.kt
@@ -1,11 +1,16 @@
 package sh.haven.app.agent
 
+import com.jcraft.jsch.SftpProgressMonitor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 import sh.haven.core.data.db.entities.ConnectionProfile
 import sh.haven.core.data.repository.ConnectionRepository
+import sh.haven.core.ffmpeg.HlsStreamServer
 import sh.haven.core.rclone.RcloneClient
 import sh.haven.core.ssh.SshSessionManager
+import sh.haven.feature.sftp.SftpStreamServer
 
 /**
  * Tool implementations for the MCP agent transport.
@@ -28,6 +33,8 @@ internal class McpTools(
     private val connectionRepository: ConnectionRepository,
     private val sshSessionManager: SshSessionManager,
     private val rcloneClient: RcloneClient,
+    private val sftpStreamServer: SftpStreamServer,
+    private val hlsStreamServer: HlsStreamServer,
 ) {
 
     /** Tool registry: name → handler. */
@@ -69,6 +76,47 @@ internal class McpTools(
                 put("required", JSONArray().put("remote"))
             },
         ) { args -> listRcloneDirectory(args) },
+
+        "list_sftp_directory" to ToolHandler(
+            description = "List files at a path on a connected SFTP profile. Requires an already-connected SSH/SFTP session for the profile.",
+            inputSchema = JSONObject().apply {
+                put("type", "object")
+                put("properties", JSONObject().apply {
+                    put("profileId", JSONObject().apply {
+                        put("type", "string")
+                        put("description", "ID of the connected SSH/SFTP profile.")
+                    })
+                    put("path", JSONObject().apply {
+                        put("type", "string")
+                        put("description", "Absolute directory path to list. Defaults to '.'")
+                    })
+                })
+                put("required", JSONArray().put("profileId"))
+            },
+        ) { args -> listSftpDirectory(args) },
+
+        "stream_sftp_file" to ToolHandler(
+            description = "Start an HLS stream for an SFTP file and return the playlist URL. Reads via a loopback HTTP bridge so no bulk download is needed. Requires a connected SSH/SFTP session. Stops any prior HLS stream.",
+            inputSchema = JSONObject().apply {
+                put("type", "object")
+                put("properties", JSONObject().apply {
+                    put("profileId", JSONObject().apply {
+                        put("type", "string")
+                        put("description", "ID of the connected SSH/SFTP profile.")
+                    })
+                    put("path", JSONObject().apply {
+                        put("type", "string")
+                        put("description", "Absolute path of the media file on the SFTP server.")
+                    })
+                })
+                put("required", JSONArray().put("profileId").put("path"))
+            },
+        ) { args -> streamSftpFile(args) },
+
+        "stop_stream" to ToolHandler(
+            description = "Stop any currently running HLS stream started by stream_sftp_file or the UI.",
+            inputSchema = emptyObjectSchema(),
+        ) { _ -> stopStream() },
     )
 
     /** Return the list of tool definitions for MCP `tools/list`. */
@@ -206,6 +254,102 @@ internal class McpTools(
             throw McpError(-32603, "Failed to list rclone remotes: ${e.message}")
         }
     }
+
+    private suspend fun listSftpDirectory(args: JSONObject): JSONObject = withContext(Dispatchers.IO) {
+        val profileId = args.optString("profileId").ifEmpty {
+            throw McpError(-32602, "Missing required argument: profileId")
+        }
+        val path = args.optString("path", ".").ifEmpty { "." }
+        val channel = sshSessionManager.openSftpForProfile(profileId)
+            ?: throw McpError(-32603, "No connected SFTP session for profile $profileId")
+        val arr = JSONArray()
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val list = channel.ls(path) as java.util.Vector<com.jcraft.jsch.ChannelSftp.LsEntry>
+            for (e in list) {
+                if (e.filename == "." || e.filename == "..") continue
+                arr.put(JSONObject().apply {
+                    put("name", e.filename)
+                    put("isDir", e.attrs.isDir)
+                    put("size", e.attrs.size)
+                    put("mtime", e.attrs.mTime.toLong())
+                    put("permissions", e.attrs.permissionsString)
+                })
+            }
+        } catch (e: Exception) {
+            throw McpError(-32603, "Failed to list $path: ${e.message}")
+        }
+        JSONObject().apply {
+            put("profileId", profileId)
+            put("path", path)
+            put("count", arr.length())
+            put("entries", arr)
+        }
+    }
+
+    private suspend fun streamSftpFile(args: JSONObject): JSONObject = withContext(Dispatchers.IO) {
+        val profileId = args.optString("profileId").ifEmpty {
+            throw McpError(-32602, "Missing required argument: profileId")
+        }
+        val path = args.optString("path").ifEmpty {
+            throw McpError(-32602, "Missing required argument: path")
+        }
+        val channel = sshSessionManager.openSftpForProfile(profileId)
+            ?: throw McpError(-32603, "No connected SFTP session for profile $profileId")
+        val size = try {
+            channel.stat(path).size
+        } catch (e: Exception) {
+            throw McpError(-32603, "Failed to stat $path: ${e.message}")
+        }
+
+        val streamPort = sftpStreamServer.start()
+        val key = sftpStreamServer.publish(
+            path = path,
+            size = size,
+            contentType = guessContentType(path),
+            opener = { offset ->
+                val ch = sshSessionManager.openSftpForProfile(profileId)
+                    ?: throw java.io.IOException("SFTP not connected for profile $profileId")
+                if (offset > 0) {
+                    ch.get(path, null as SftpProgressMonitor?, offset)
+                } else {
+                    ch.get(path)
+                }
+            },
+        )
+        val sourceUrl = "http://127.0.0.1:$streamPort/$key"
+        val hlsPort = hlsStreamServer.startFile(sourceUrl)
+        JSONObject().apply {
+            put("profileId", profileId)
+            put("path", path)
+            put("size", size)
+            put("sourceUrl", sourceUrl)
+            put("hlsPort", hlsPort)
+            put("playlistUrl", "http://127.0.0.1:$hlsPort/stream.m3u8")
+            put("playerUrl", "http://127.0.0.1:$hlsPort/")
+        }
+    }
+
+    private fun stopStream(): JSONObject {
+        hlsStreamServer.stop()
+        return JSONObject().apply { put("stopped", true) }
+    }
+
+    private fun guessContentType(name: String): String =
+        when (name.substringAfterLast('.', "").lowercase()) {
+            "mp4", "m4v" -> "video/mp4"
+            "mkv" -> "video/x-matroska"
+            "webm" -> "video/webm"
+            "mov" -> "video/quicktime"
+            "avi" -> "video/x-msvideo"
+            "ts" -> "video/mp2t"
+            "mp3" -> "audio/mpeg"
+            "m4a", "aac" -> "audio/aac"
+            "ogg", "oga", "opus" -> "audio/ogg"
+            "flac" -> "audio/flac"
+            "wav" -> "audio/wav"
+            else -> "application/octet-stream"
+        }
 
     private fun listRcloneDirectory(args: JSONObject): JSONObject {
         val remote = args.optString("remote").ifEmpty {

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpScreen.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpScreen.kt
@@ -726,7 +726,7 @@ fun SftpScreen(
                                     { viewModel.openConvertDialog(entry) }
                                 } else null,
                                 onStream = if (!entry.isDirectory && entry.isMediaFile(mediaExtensions) &&
-                                    (viewModel.isLocalProfile() || isRclone)) {
+                                    !viewModel.isSmbProfile()) {
                                     { viewModel.streamFile(entry) }
                                 } else null,
                                 onPlay = if (isRclone && entry.isMediaFile(mediaExtensions)) {

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpStreamServer.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpStreamServer.kt
@@ -1,0 +1,220 @@
+package sh.haven.feature.sftp
+
+import android.util.Log
+import java.io.Closeable
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.concurrent.thread
+
+private const val TAG = "SftpStreamServer"
+
+/**
+ * Loopback HTTP server that exposes SFTP files to ffmpeg so it can read
+ * them with Range requests rather than having the caller download the
+ * whole file to cache first.
+ *
+ * Callers register one file at a time via [publish], passing a per-file
+ * [Opener] that knows how to re-open an InputStream at a given byte
+ * offset on whatever `ChannelSftp` they control. This keeps the server
+ * independent of any specific session manager or profile lookup and lets
+ * both the SFTP browser ViewModel and the MCP agent use the same server.
+ *
+ * SFTP channels are not safe to read from concurrently, so all body
+ * writes are serialized on an internal lock. That's acceptable for
+ * single-stream playback: ffmpeg issues one Range request at a time per
+ * input.
+ */
+@Singleton
+class SftpStreamServer @Inject constructor() : Closeable {
+
+    fun interface Opener {
+        @Throws(Exception::class)
+        fun open(offset: Long): InputStream
+    }
+
+    private data class Entry(
+        val path: String,
+        val size: Long,
+        val contentType: String,
+        val opener: Opener,
+    )
+
+    private var serverSocket: ServerSocket? = null
+    private var serverThread: Thread? = null
+    private val entries = ConcurrentHashMap<String, Entry>()
+    private val channelLock = Any()
+
+    @Volatile
+    var port: Int = 0
+        private set
+
+    @Volatile
+    private var running: Boolean = false
+
+    /** Start the loopback server. Returns the bound port. Idempotent. */
+    fun start(preferredPort: Int = 0): Int {
+        if (running) return port
+        val ss = ServerSocket(preferredPort, 4, InetAddress.getByName("127.0.0.1"))
+        serverSocket = ss
+        port = ss.localPort
+        running = true
+        serverThread = thread(name = "sftp-stream-http", isDaemon = true) {
+            Log.i(TAG, "listening on 127.0.0.1:$port")
+            while (running) {
+                val client = try {
+                    ss.accept()
+                } catch (_: Exception) {
+                    break
+                }
+                thread(name = "sftp-stream-client", isDaemon = true) { handle(client) }
+            }
+        }
+        return port
+    }
+
+    /**
+     * Register a file and return the URL path segment to use. The key is
+     * the URL-encoded file path. Re-publishing the same key replaces the
+     * previous opener so a caller can point ffmpeg at the same URL with
+     * a fresh channel after reconnecting.
+     */
+    fun publish(
+        path: String,
+        size: Long,
+        contentType: String = "application/octet-stream",
+        opener: Opener,
+    ): String {
+        val key = path.trimStart('/').split('/').joinToString("/") {
+            java.net.URLEncoder.encode(it, "UTF-8").replace("+", "%20")
+        }
+        entries[key] = Entry(path = path, size = size, contentType = contentType, opener = opener)
+        return key
+    }
+
+    override fun close() = stop()
+
+    fun stop() {
+        running = false
+        try { serverSocket?.close() } catch (_: Exception) {}
+        serverSocket = null
+        serverThread = null
+        entries.clear()
+        port = 0
+    }
+
+    private fun handle(socket: Socket) {
+        try {
+            socket.use { s ->
+                val reader = s.getInputStream().bufferedReader()
+                val requestLine = reader.readLine() ?: return
+                val parts = requestLine.split(' ')
+                if (parts.size < 2) return
+                val method = parts[0]
+                val target = parts[1]
+
+                var rangeHeader: String? = null
+                while (true) {
+                    val line = reader.readLine() ?: break
+                    if (line.isEmpty()) break
+                    if (line.startsWith("Range:", ignoreCase = true)) {
+                        rangeHeader = line.substringAfter(':').trim()
+                    }
+                }
+
+                val key = target.removePrefix("/").substringBefore('?')
+                val out = s.getOutputStream()
+                val entry = entries[key]
+                if (entry == null) {
+                    writeStatus(out, 404, "Not Found")
+                    return
+                }
+
+                val size = entry.size
+                var start = 0L
+                var end = size - 1
+                var isPartial = false
+                if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
+                    val spec = rangeHeader.removePrefix("bytes=")
+                    val dash = spec.indexOf('-')
+                    if (dash >= 0) {
+                        val a = spec.substring(0, dash)
+                        val b = spec.substring(dash + 1)
+                        if (a.isNotEmpty()) {
+                            start = a.toLongOrNull() ?: 0L
+                            if (b.isNotEmpty()) {
+                                end = (b.toLongOrNull() ?: end).coerceAtMost(size - 1)
+                            }
+                        } else if (b.isNotEmpty()) {
+                            val n = b.toLongOrNull() ?: 0L
+                            start = (size - n).coerceAtLeast(0L)
+                        }
+                        isPartial = true
+                    }
+                }
+                if (start < 0 || start >= size || end < start) {
+                    val hdr = "HTTP/1.1 416 Range Not Satisfiable\r\n" +
+                        "Content-Range: bytes */$size\r\n" +
+                        "Content-Length: 0\r\nConnection: close\r\n\r\n"
+                    out.write(hdr.toByteArray())
+                    out.flush()
+                    return
+                }
+
+                val length = end - start + 1
+                val hdr = buildString {
+                    if (isPartial) {
+                        append("HTTP/1.1 206 Partial Content\r\n")
+                        append("Content-Range: bytes $start-$end/$size\r\n")
+                    } else {
+                        append("HTTP/1.1 200 OK\r\n")
+                    }
+                    append("Content-Type: ${entry.contentType}\r\n")
+                    append("Content-Length: $length\r\n")
+                    append("Accept-Ranges: bytes\r\n")
+                    append("Access-Control-Allow-Origin: *\r\n")
+                    append("Connection: close\r\n\r\n")
+                }
+                out.write(hdr.toByteArray())
+                if (method.equals("HEAD", ignoreCase = true)) {
+                    out.flush()
+                    return
+                }
+
+                synchronized(channelLock) {
+                    val stream = try {
+                        entry.opener.open(start)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "open ${entry.path}@$start failed", e)
+                        return
+                    }
+                    stream.use { inp ->
+                        val buf = ByteArray(64 * 1024)
+                        var remaining = length
+                        while (remaining > 0) {
+                            val want = minOf(buf.size.toLong(), remaining).toInt()
+                            val n = inp.read(buf, 0, want)
+                            if (n < 0) break
+                            out.write(buf, 0, n)
+                            remaining -= n
+                        }
+                        out.flush()
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "client ended: ${e.message}")
+        }
+    }
+
+    private fun writeStatus(out: OutputStream, code: Int, reason: String) {
+        val resp = "HTTP/1.1 $code $reason\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        out.write(resp.toByteArray())
+        out.flush()
+    }
+}

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
@@ -103,6 +103,7 @@ class SftpViewModel @Inject constructor(
     private val preferencesRepository: UserPreferencesRepository,
     private val ffmpegExecutor: sh.haven.core.ffmpeg.FfmpegExecutor,
     val hlsStreamServer: sh.haven.core.ffmpeg.HlsStreamServer,
+    private val sftpStreamServer: SftpStreamServer,
     @ApplicationContext private val appContext: Context,
 ) : ViewModel() {
 
@@ -306,6 +307,39 @@ class SftpViewModel @Inject constructor(
 
     private var sftpChannel: ChannelSftp? = null
     private var activeSmbClient: SmbClient? = null
+
+    /**
+     * Build an [SftpStreamServer.Opener] for [entry] on the currently
+     * active profile. The opener captures [profileId] (not a channel) so
+     * it re-resolves against whichever browse channel is live at read
+     * time — important across reconnects.
+     */
+    private fun sftpOpener(profileId: String, path: String): SftpStreamServer.Opener =
+        SftpStreamServer.Opener { offset ->
+            val channel = getOrOpenChannel(profileId)
+                ?: throw java.io.IOException("SFTP not connected")
+            if (offset > 0) {
+                channel.get(path, null as SftpProgressMonitor?, offset)
+            } else {
+                channel.get(path)
+            }
+        }
+
+    private fun guessContentType(name: String): String = when (name.substringAfterLast('.', "").lowercase()) {
+        "mp4", "m4v" -> "video/mp4"
+        "mkv" -> "video/x-matroska"
+        "webm" -> "video/webm"
+        "mov" -> "video/quicktime"
+        "avi" -> "video/x-msvideo"
+        "ts" -> "video/mp2t"
+        "mp3" -> "audio/mpeg"
+        "m4a", "aac" -> "audio/aac"
+        "ogg", "oga" -> "audio/ogg"
+        "flac" -> "audio/flac"
+        "wav" -> "audio/wav"
+        "opus" -> "audio/opus"
+        else -> "application/octet-stream"
+    }
 
     /** Tracks which active profile is SMB (vs SFTP). */
     private val _isSmbProfile = MutableStateFlow(false)
@@ -593,6 +627,7 @@ class SftpViewModel @Inject constructor(
 
     /** Whether the active profile is the local filesystem. */
     fun isLocalProfile(): Boolean = _isLocalProfile.value
+    fun isSmbProfile(): Boolean = _isSmbProfile.value
 
     /** True when the local file browser needs MANAGE_EXTERNAL_STORAGE permission. */
     val needsStoragePermission: Boolean
@@ -978,28 +1013,42 @@ class SftpViewModel @Inject constructor(
      * - **Local** files: ffmpeg reads the path directly.
      * - **Rclone** files: ffmpeg reads via the rclone HTTP media server
      *   (Range requests, VFS disk cache) — no bulk download.
-     * - **SFTP/SMB**: not supported (no HTTP serve equivalent). Would
-     *   require either downloading to cache first or piping via ssh/smb
-     *   into ffmpeg's stdin.
+     * - **SFTP** files: ffmpeg reads via the loopback [sftpStreamServer]
+     *   which fronts `ChannelSftp.get(path, skip)` with HTTP Range support.
+     * - **SMB**: not supported yet (no HTTP bridge).
      */
     fun streamFile(entry: SftpEntry) {
-        Log.w(TAG, "streamFile: ${entry.path} isLocal=${_isLocalProfile.value} isRclone=${_isRcloneProfile.value} ffmpegAvail=${ffmpegExecutor.isAvailable()}")
-        if (!_isLocalProfile.value && !_isRcloneProfile.value) {
-            _error.value = "Streaming is only available for local and cloud files"
+        Log.w(TAG, "streamFile: ${entry.path} isLocal=${_isLocalProfile.value} isRclone=${_isRcloneProfile.value} isSmb=${_isSmbProfile.value} ffmpegAvail=${ffmpegExecutor.isAvailable()}")
+        if (_isSmbProfile.value) {
+            _error.value = "Streaming is not supported for SMB yet"
             return
         }
         viewModelScope.launch {
             try {
                 // Resolve the ffmpeg input path or URL
-                val streamInput: String = if (_isLocalProfile.value) {
-                    entry.path
-                } else {
-                    val port = ensureMediaServer()
-                    val encodedPath = entry.path
-                        .trimStart('/')
-                        .split('/')
-                        .joinToString("/") { java.net.URLEncoder.encode(it, "UTF-8").replace("+", "%20") }
-                    "http://127.0.0.1:$port/$encodedPath"
+                val streamInput: String = when {
+                    _isLocalProfile.value -> entry.path
+                    _isRcloneProfile.value -> {
+                        val port = ensureMediaServer()
+                        val encodedPath = entry.path
+                            .trimStart('/')
+                            .split('/')
+                            .joinToString("/") { java.net.URLEncoder.encode(it, "UTF-8").replace("+", "%20") }
+                        "http://127.0.0.1:$port/$encodedPath"
+                    }
+                    else -> {
+                        // SFTP via loopback HTTP bridge
+                        val profileId = _activeProfileId.value
+                            ?: throw IllegalStateException("No active profile")
+                        val port = withContext(Dispatchers.IO) { sftpStreamServer.start() }
+                        val key = sftpStreamServer.publish(
+                            path = entry.path,
+                            size = entry.size,
+                            contentType = guessContentType(entry.name),
+                            opener = sftpOpener(profileId, entry.path),
+                        )
+                        "http://127.0.0.1:$port/$key"
+                    }
                 }
                 Log.w(TAG, "Starting HLS stream for $streamInput")
                 val port = hlsStreamServer.startFile(streamInput)
@@ -1081,28 +1130,35 @@ class SftpViewModel @Inject constructor(
                         isRemote = true
                         Log.d(TAG, "preparePreview: using rclone HTTP URL $inputSource")
                     }
-                    else -> {
-                        // SFTP/SMB — download to cache once, then reuse
+                    _isSmbProfile.value -> {
+                        // SMB — still downloads to cache; no HTTP bridge yet.
                         val cached = java.io.File(appContext.cacheDir, "ffmpeg_in_${entry.name}")
                         if (!cached.exists() || cached.length() == 0L) {
                             withContext(Dispatchers.IO) {
                                 cached.outputStream().use { out ->
-                                    if (_isSmbProfile.value) {
-                                        val client = activeSmbClient ?: throw IllegalStateException("SMB not connected")
-                                        client.download(entry.path, out) { _, _ -> }
-                                    } else {
-                                        val channel = getOrOpenChannel(profileId) ?: throw IllegalStateException("Not connected")
-                                        channel.get(entry.path, out, object : SftpProgressMonitor {
-                                            override fun init(op: Int, src: String, dest: String, max: Long) {}
-                                            override fun count(bytes: Long): Boolean = true
-                                            override fun end() {}
-                                        })
-                                    }
+                                    val client = activeSmbClient ?: throw IllegalStateException("SMB not connected")
+                                    client.download(entry.path, out) { _, _ -> }
                                 }
                             }
                         }
                         inputSource = cached.absolutePath
                         isRemote = false
+                    }
+                    else -> {
+                        // SFTP — stream via loopback HTTP so ffmpeg uses Range
+                        // requests (probe typically reads just the moov atom,
+                        // a few hundred KB) instead of downloading the whole
+                        // file to cache.
+                        val port = withContext(Dispatchers.IO) { sftpStreamServer.start() }
+                        val key = sftpStreamServer.publish(
+                            path = entry.path,
+                            size = entry.size,
+                            contentType = guessContentType(entry.name),
+                            opener = sftpOpener(profileId, entry.path),
+                        )
+                        inputSource = "http://127.0.0.1:$port/$key"
+                        isRemote = true
+                        Log.d(TAG, "preparePreview: using SFTP HTTP URL $inputSource")
                     }
                 }
                 previewInputSource = inputSource


### PR DESCRIPTION
## Summary

Closes #87.

Adds `.github/dependabot.yml` covering the four package ecosystems present in this repo:

- **GitHub Actions** (`.github/workflows/ci.yml`, `release.yml`)
- **Gradle** (root; Dependabot reads `gradle/libs.versions.toml` automatically)
- **Cargo** (`rdp-kotlin/rust`)
- **Go modules** (`rclone-android/go`)

All four are on a **weekly** schedule. The issue suggested daily defaults, but Gradle on a multi-module Android project can produce a lot of noise — weekly is a less disruptive starting point that still keeps deps fresh and can be dialled up later if it feels slow. Open-PR caps are set modestly (5–10) so the first Dependabot run after enablement doesn't flood the review queue.

## Test plan

- [ ] Merge and wait for the first Dependabot sync to confirm each ecosystem is picked up
- [ ] Review the first wave of PRs and adjust cadence / ignore rules if any ecosystem is too noisy