### PR TITLE
Auto-switch terminal color scheme on system light/dark mode

### DIFF
--- a/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
@@ -826,6 +826,14 @@ class UserPreferencesRepository @Inject constructor(
         val label: String,
         val background: Long,
         val foreground: Long,
+        /**
+         * 16-entry ANSI palette in libvterm order:
+         *   0..7  = normal  black, red, green, yellow, blue, magenta, cyan, white
+         *   8..15 = bright  black, red, green, yellow, blue, magenta, cyan, white
+         * Passed to the emulator via `applyColorScheme` so SGR-coloured text
+         * (most prompts) tracks the scheme, not libvterm's stock palette.
+         */
+        val ansi: LongArray,
     ) {
         /**
          * Sentinel scheme — actual fg/bg come from the live
@@ -835,25 +843,152 @@ class UserPreferencesRepository @Inject constructor(
          * `TerminalViewModel`); the Compose layer overrides immediately
          * via `setDefaultColors`. Call sites that *can* reach the
          * theme should check [isDynamic] and use the live colours.
+         *
+         * The palette is a static neutral fallback (Catppuccin Mocha); a
+         * future improvement could derive it from the live Material 3
+         * tonal palettes.
          */
-        MATERIAL_YOU("Material You", 0xFF1A1A1A, 0xFFE0E0E0),
-        HAVEN("Haven", 0xFF1A1A2E, 0xFF00E676),
-        CLASSIC_GREEN("Classic Green", 0xFF000000, 0xFF00FF00),
-        LIGHT("Light", 0xFFFFFFFF, 0xFF1A1A1A),
-        SOLARIZED_DARK("Solarized Dark", 0xFF002B36, 0xFF839496),
-        DRACULA("Dracula", 0xFF282A36, 0xFFF8F8F2),
-        MONOKAI("Monokai", 0xFF272822, 0xFFF8F8F2),
-        NORD("Nord", 0xFF2E3440, 0xFFD8DEE9),
-        GRUVBOX("Gruvbox", 0xFF282828, 0xFFEBDBB2),
-        TOKYO_NIGHT("Tokyo Night", 0xFF1A1B26, 0xFFA9B1D6),
-        QBASIC("QBasic", 0xFF0000AA, 0xFFAAAAAA),
-        AMBER("Amber", 0xFF1A1000, 0xFFFFB000),
-        PINK("Pink", 0xFF2D001E, 0xFFFF9EC6),
-        LAVENDER("Lavender", 0xFF1E1629, 0xFFCDB4DB),
-        OCEAN("Ocean", 0xFF0A192F, 0xFF64FFDA);
+        MATERIAL_YOU(
+            "Material You", 0xFF1A1A1A, 0xFFE0E0E0,
+            longArrayOf(
+                0xFF45475A, 0xFFF38BA8, 0xFFA6E3A1, 0xFFF9E2AF,
+                0xFF89B4FA, 0xFFF5C2E7, 0xFF94E2D5, 0xFFBAC2DE,
+                0xFF585B70, 0xFFEBA0AC, 0xFFB1E3AB, 0xFFFCEAB5,
+                0xFF96BDFD, 0xFFF7CEEC, 0xFF9EE9DC, 0xFFA6ADC8,
+            ),
+        ),
+        HAVEN(
+            "Haven", 0xFF1A1A2E, 0xFF00E676,
+            longArrayOf(
+                0xFF1A1A2E, 0xFFFF5C8A, 0xFF00E676, 0xFFFFD54F,
+                0xFF4FC3F7, 0xFFCE93D8, 0xFF80DEEA, 0xFFB0BEC5,
+                0xFF424242, 0xFFFF8A80, 0xFF69F0AE, 0xFFFFE082,
+                0xFF82B1FF, 0xFFE1BEE7, 0xFFA7FFEB, 0xFFECEFF1,
+            ),
+        ),
+        CLASSIC_GREEN(
+            "Classic Green", 0xFF000000, 0xFF00FF00,
+            longArrayOf(
+                0xFF000000, 0xFF008800, 0xFF00BB00, 0xFF00CC00,
+                0xFF005500, 0xFF007733, 0xFF009966, 0xFF00BB00,
+                0xFF004400, 0xFF00CC00, 0xFF00FF00, 0xFF55FF55,
+                0xFF007722, 0xFF00CC66, 0xFF00FFAA, 0xFF66FF66,
+            ),
+        ),
+        LIGHT(
+            "Light", 0xFFFFFFFF, 0xFF1A1A1A,
+            longArrayOf(
+                0xFF073642, 0xFFDC322F, 0xFF859900, 0xFFB58900,
+                0xFF268BD2, 0xFFD33682, 0xFF2AA198, 0xFFEEE8D5,
+                0xFF002B36, 0xFFCB4B16, 0xFF586E75, 0xFF657B83,
+                0xFF839496, 0xFF6C71C4, 0xFF93A1A1, 0xFFFDF6E3,
+            ),
+        ),
+        SOLARIZED_DARK(
+            "Solarized Dark", 0xFF002B36, 0xFF839496,
+            longArrayOf(
+                0xFF073642, 0xFFDC322F, 0xFF859900, 0xFFB58900,
+                0xFF268BD2, 0xFFD33682, 0xFF2AA198, 0xFFEEE8D5,
+                0xFF002B36, 0xFFCB4B16, 0xFF586E75, 0xFF657B83,
+                0xFF839496, 0xFF6C71C4, 0xFF93A1A1, 0xFFFDF6E3,
+            ),
+        ),
+        DRACULA(
+            "Dracula", 0xFF282A36, 0xFFF8F8F2,
+            longArrayOf(
+                0xFF21222C, 0xFFFF5555, 0xFF50FA7B, 0xFFF1FA8C,
+                0xFFBD93F9, 0xFFFF79C6, 0xFF8BE9FD, 0xFFF8F8F2,
+                0xFF6272A4, 0xFFFF6E6E, 0xFF69FF94, 0xFFFFFFA5,
+                0xFFD6ACFF, 0xFFFF92DF, 0xFFA4FFFF, 0xFFFFFFFF,
+            ),
+        ),
+        MONOKAI(
+            "Monokai", 0xFF272822, 0xFFF8F8F2,
+            longArrayOf(
+                0xFF272822, 0xFFF92672, 0xFFA6E22E, 0xFFF4BF75,
+                0xFF66D9EF, 0xFFAE81FF, 0xFFA1EFE4, 0xFFF8F8F2,
+                0xFF75715E, 0xFFF92672, 0xFFA6E22E, 0xFFE6DB74,
+                0xFF66D9EF, 0xFFAE81FF, 0xFFA1EFE4, 0xFFF9F8F5,
+            ),
+        ),
+        NORD(
+            "Nord", 0xFF2E3440, 0xFFD8DEE9,
+            longArrayOf(
+                0xFF3B4252, 0xFFBF616A, 0xFFA3BE8C, 0xFFEBCB8B,
+                0xFF81A1C1, 0xFFB48EAD, 0xFF88C0D0, 0xFFE5E9F0,
+                0xFF4C566A, 0xFFBF616A, 0xFFA3BE8C, 0xFFEBCB8B,
+                0xFF81A1C1, 0xFFB48EAD, 0xFF8FBCBB, 0xFFECEFF4,
+            ),
+        ),
+        GRUVBOX(
+            "Gruvbox", 0xFF282828, 0xFFEBDBB2,
+            longArrayOf(
+                0xFF282828, 0xFFCC241D, 0xFF98971A, 0xFFD79921,
+                0xFF458588, 0xFFB16286, 0xFF689D6A, 0xFFA89984,
+                0xFF928374, 0xFFFB4934, 0xFFB8BB26, 0xFFFABD2F,
+                0xFF83A598, 0xFFD3869B, 0xFF8EC07C, 0xFFEBDBB2,
+            ),
+        ),
+        TOKYO_NIGHT(
+            "Tokyo Night", 0xFF1A1B26, 0xFFA9B1D6,
+            longArrayOf(
+                0xFF15161E, 0xFFF7768E, 0xFF9ECE6A, 0xFFE0AF68,
+                0xFF7AA2F7, 0xFFBB9AF7, 0xFF7DCFFF, 0xFFA9B1D6,
+                0xFF414868, 0xFFF7768E, 0xFF9ECE6A, 0xFFE0AF68,
+                0xFF7AA2F7, 0xFFBB9AF7, 0xFF7DCFFF, 0xFFC0CAF5,
+            ),
+        ),
+        QBASIC(
+            "QBasic", 0xFF0000AA, 0xFFAAAAAA,
+            longArrayOf(
+                0xFF000000, 0xFFAA0000, 0xFF00AA00, 0xFFAA5500,
+                0xFF0000AA, 0xFFAA00AA, 0xFF00AAAA, 0xFFAAAAAA,
+                0xFF555555, 0xFFFF5555, 0xFF55FF55, 0xFFFFFF55,
+                0xFF5555FF, 0xFFFF55FF, 0xFF55FFFF, 0xFFFFFFFF,
+            ),
+        ),
+        AMBER(
+            "Amber", 0xFF1A1000, 0xFFFFB000,
+            longArrayOf(
+                0xFF1A1000, 0xFF884400, 0xFFAA6600, 0xFFCC7700,
+                0xFF553300, 0xFF884422, 0xFFAA5511, 0xFFCC8833,
+                0xFF443300, 0xFFCC6600, 0xFFDD8822, 0xFFFFB000,
+                0xFF775500, 0xFFCC7733, 0xFFDD9944, 0xFFFFCC66,
+            ),
+        ),
+        PINK(
+            "Pink", 0xFF2D001E, 0xFFFF9EC6,
+            longArrayOf(
+                0xFF2D001E, 0xFFFF4081, 0xFFFFAB91, 0xFFFFD180,
+                0xFFCE93D8, 0xFFFF80AB, 0xFFFFB2DD, 0xFFFFCCDD,
+                0xFF550022, 0xFFFF80AB, 0xFFFFCCBC, 0xFFFFE0B2,
+                0xFFE1BEE7, 0xFFFFB6C1, 0xFFFFD8E8, 0xFFFFE6F0,
+            ),
+        ),
+        LAVENDER(
+            "Lavender", 0xFF1E1629, 0xFFCDB4DB,
+            longArrayOf(
+                0xFF1E1629, 0xFFE57373, 0xFFB39DDB, 0xFFFFCC80,
+                0xFF9575CD, 0xFFCE93D8, 0xFFB0BEC5, 0xFFCDB4DB,
+                0xFF4A3F61, 0xFFFF8A80, 0xFFD1C4E9, 0xFFFFE082,
+                0xFFB39DDB, 0xFFE1BEE7, 0xFFCFD8DC, 0xFFEDE7F6,
+            ),
+        ),
+        OCEAN(
+            "Ocean", 0xFF0A192F, 0xFF64FFDA,
+            longArrayOf(
+                0xFF0A192F, 0xFFFF6E6E, 0xFF64FFDA, 0xFFFFD180,
+                0xFF82B1FF, 0xFF80D8FF, 0xFF18FFFF, 0xFFCFD8DC,
+                0xFF1F3A5F, 0xFFFF8A80, 0xFFA7FFEB, 0xFFFFE082,
+                0xFF8C9EFF, 0xFFB388FF, 0xFF84FFFF, 0xFFECEFF1,
+            ),
+        );
 
         /** True when fg/bg should be sourced from the live system theme rather than the enum's static longs. */
         val isDynamic: Boolean get() = this == MATERIAL_YOU
+
+        /** Snapshot of [ansi] as a 16-entry ARGB IntArray, ready for `applyColorScheme`. */
+        fun ansiPaletteArgb(): IntArray = IntArray(16) { ansi[it].toInt() }
 
         companion object {
             fun fromString(value: String?): TerminalColorScheme =

--- a/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
+++ b/core/data/src/main/kotlin/sh/haven/core/data/preferences/UserPreferencesRepository.kt
@@ -29,6 +29,9 @@ class UserPreferencesRepository @Inject constructor(
     private val reticulumHostKey = stringPreferencesKey("reticulum_host")
     private val reticulumPortKey = intPreferencesKey("reticulum_port")
     private val terminalColorSchemeKey = stringPreferencesKey("terminal_color_scheme")
+    private val terminalAutoSwitchSchemeKey = booleanPreferencesKey("terminal_auto_switch_scheme")
+    private val terminalLightColorSchemeKey = stringPreferencesKey("terminal_light_color_scheme")
+    private val terminalDarkColorSchemeKey = stringPreferencesKey("terminal_dark_color_scheme")
     private val toolbarRowsKey = intPreferencesKey("toolbar_rows") // legacy
     private val toolbarRow1Key = stringPreferencesKey("toolbar_row1") // legacy
     private val toolbarRow2Key = stringPreferencesKey("toolbar_row2") // legacy
@@ -777,6 +780,45 @@ class UserPreferencesRepository @Inject constructor(
     suspend fun setTerminalColorScheme(scheme: TerminalColorScheme) {
         dataStore.edit { prefs ->
             prefs[terminalColorSchemeKey] = scheme.name
+        }
+    }
+
+    /**
+     * When true, the active terminal scheme follows the system light/dark
+     * mode — [terminalLightColorScheme] in light, [terminalDarkColorScheme]
+     * in dark. The plain [terminalColorScheme] pref is used otherwise.
+     */
+    val terminalAutoSwitchScheme: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[terminalAutoSwitchSchemeKey] ?: false
+    }
+
+    suspend fun setTerminalAutoSwitchScheme(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[terminalAutoSwitchSchemeKey] = enabled
+        }
+    }
+
+    val terminalLightColorScheme: Flow<TerminalColorScheme> = dataStore.data.map { prefs ->
+        prefs[terminalLightColorSchemeKey]?.let { name ->
+            TerminalColorScheme.entries.find { it.name == name }
+        } ?: TerminalColorScheme.LIGHT
+    }
+
+    suspend fun setTerminalLightColorScheme(scheme: TerminalColorScheme) {
+        dataStore.edit { prefs ->
+            prefs[terminalLightColorSchemeKey] = scheme.name
+        }
+    }
+
+    val terminalDarkColorScheme: Flow<TerminalColorScheme> = dataStore.data.map { prefs ->
+        prefs[terminalDarkColorSchemeKey]?.let { name ->
+            TerminalColorScheme.entries.find { it.name == name }
+        } ?: TerminalColorScheme.HAVEN
+    }
+
+    suspend fun setTerminalDarkColorScheme(scheme: TerminalColorScheme) {
+        dataStore.edit { prefs ->
+            prefs[terminalDarkColorSchemeKey] = scheme.name
         }
     }
 

--- a/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsScreen.kt
@@ -151,6 +151,9 @@ fun SettingsScreen(
     val theme by viewModel.theme.collectAsState()
     val sessionManager by viewModel.sessionManager.collectAsState()
     val colorScheme by viewModel.terminalColorScheme.collectAsState()
+    val autoSwitchColorScheme by viewModel.terminalAutoSwitchScheme.collectAsState()
+    val lightColorScheme by viewModel.terminalLightColorScheme.collectAsState()
+    val darkColorScheme by viewModel.terminalDarkColorScheme.collectAsState()
     val toolbarLayout by viewModel.toolbarLayout.collectAsState()
     val toolbarLayoutJson by viewModel.toolbarLayoutJson.collectAsState()
     val navBlockMode by viewModel.navBlockMode.collectAsState()
@@ -196,6 +199,8 @@ fun SettingsScreen(
     var showSessionManagerDialog by remember { mutableStateOf(false) }
     var showThemeDialog by remember { mutableStateOf(false) }
     var showColorSchemeDialog by remember { mutableStateOf(false) }
+    var showLightColorSchemeDialog by remember { mutableStateOf(false) }
+    var showDarkColorSchemeDialog by remember { mutableStateOf(false) }
     var showAboutDialog by remember { mutableStateOf(false) }
     var showToolbarConfigDialog by remember { mutableStateOf(false) }
     var showKeyboardModeDialog by remember { mutableStateOf(false) }
@@ -354,12 +359,34 @@ fun SettingsScreen(
             subtitle = theme.label,
             onClick = { showThemeDialog = true },
         )
-        SettingsItem(
+        SettingsToggleItem(
             icon = Icons.Filled.Palette,
-            title = stringResource(R.string.settings_color_scheme_title),
-            subtitle = colorScheme.label,
-            onClick = { showColorSchemeDialog = true },
+            title = stringResource(R.string.settings_color_scheme_auto_switch_title),
+            subtitle = stringResource(R.string.settings_color_scheme_auto_switch_subtitle),
+            checked = autoSwitchColorScheme,
+            onCheckedChange = viewModel::setTerminalAutoSwitchScheme,
         )
+        if (autoSwitchColorScheme) {
+            SettingsItem(
+                icon = Icons.Filled.Palette,
+                title = stringResource(R.string.settings_color_scheme_light_title),
+                subtitle = lightColorScheme.label,
+                onClick = { showLightColorSchemeDialog = true },
+            )
+            SettingsItem(
+                icon = Icons.Filled.Palette,
+                title = stringResource(R.string.settings_color_scheme_dark_title),
+                subtitle = darkColorScheme.label,
+                onClick = { showDarkColorSchemeDialog = true },
+            )
+        } else {
+            SettingsItem(
+                icon = Icons.Filled.Palette,
+                title = stringResource(R.string.settings_color_scheme_title),
+                subtitle = colorScheme.label,
+                onClick = { showColorSchemeDialog = true },
+            )
+        }
         SettingsItem(
             icon = Icons.Filled.TextFields,
             title = stringResource(R.string.settings_font_size_title),
@@ -1150,6 +1177,30 @@ fun SettingsScreen(
         )
     }
 
+    if (showLightColorSchemeDialog) {
+        ColorSchemeDialog(
+            currentScheme = lightColorScheme,
+            titleRes = R.string.settings_color_scheme_light_dialog_title,
+            onDismiss = { showLightColorSchemeDialog = false },
+            onSelect = { selected ->
+                viewModel.setTerminalLightColorScheme(selected)
+                showLightColorSchemeDialog = false
+            },
+        )
+    }
+
+    if (showDarkColorSchemeDialog) {
+        ColorSchemeDialog(
+            currentScheme = darkColorScheme,
+            titleRes = R.string.settings_color_scheme_dark_dialog_title,
+            onDismiss = { showDarkColorSchemeDialog = false },
+            onSelect = { selected ->
+                viewModel.setTerminalDarkColorScheme(selected)
+                showDarkColorSchemeDialog = false
+            },
+        )
+    }
+
     if (showLockTimeoutDialog) {
         AlertDialog(
             onDismissRequest = { showLockTimeoutDialog = false },
@@ -1645,10 +1696,11 @@ private fun ColorSchemeDialog(
     currentScheme: UserPreferencesRepository.TerminalColorScheme,
     onDismiss: () -> Unit,
     onSelect: (UserPreferencesRepository.TerminalColorScheme) -> Unit,
+    titleRes: Int = R.string.settings_color_scheme_dialog_title,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.settings_color_scheme_dialog_title)) },
+        title = { Text(stringResource(titleRes)) },
         text = {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 UserPreferencesRepository.TerminalColorScheme.entries.forEach { scheme ->

--- a/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/sh/haven/feature/settings/SettingsViewModel.kt
@@ -288,6 +288,26 @@ class SettingsViewModel @Inject constructor(
                 UserPreferencesRepository.TerminalColorScheme.HAVEN,
             )
 
+    val terminalAutoSwitchScheme: StateFlow<Boolean> =
+        preferencesRepository.terminalAutoSwitchScheme
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    val terminalLightColorScheme: StateFlow<UserPreferencesRepository.TerminalColorScheme> =
+        preferencesRepository.terminalLightColorScheme
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5000),
+                UserPreferencesRepository.TerminalColorScheme.LIGHT,
+            )
+
+    val terminalDarkColorScheme: StateFlow<UserPreferencesRepository.TerminalColorScheme> =
+        preferencesRepository.terminalDarkColorScheme
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(5000),
+                UserPreferencesRepository.TerminalColorScheme.HAVEN,
+            )
+
     val toolbarLayout: StateFlow<ToolbarLayout> = preferencesRepository.toolbarLayout
         .stateIn(
             viewModelScope,
@@ -522,6 +542,24 @@ class SettingsViewModel @Inject constructor(
     fun setTerminalColorScheme(scheme: UserPreferencesRepository.TerminalColorScheme) {
         viewModelScope.launch {
             preferencesRepository.setTerminalColorScheme(scheme)
+        }
+    }
+
+    fun setTerminalAutoSwitchScheme(enabled: Boolean) {
+        viewModelScope.launch {
+            preferencesRepository.setTerminalAutoSwitchScheme(enabled)
+        }
+    }
+
+    fun setTerminalLightColorScheme(scheme: UserPreferencesRepository.TerminalColorScheme) {
+        viewModelScope.launch {
+            preferencesRepository.setTerminalLightColorScheme(scheme)
+        }
+    }
+
+    fun setTerminalDarkColorScheme(scheme: UserPreferencesRepository.TerminalColorScheme) {
+        viewModelScope.launch {
+            preferencesRepository.setTerminalDarkColorScheme(scheme)
         }
     }
 

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -60,6 +60,12 @@
     <string name="settings_tap_to_position_title">Tap to move cursor on supported prompts</string>
     <string name="settings_tap_to_position_subtitle">Tap inside a shell prompt to move the cursor to that column. Requires OSC 133 prompt markers (starship, fish 3.6+, recent bash/zsh shell-integration setups). No effect on shells that don\'t emit them</string>
     <string name="settings_color_scheme_title">Terminal color scheme</string>
+    <string name="settings_color_scheme_auto_switch_title">Auto-switch with system theme</string>
+    <string name="settings_color_scheme_auto_switch_subtitle">Use different terminal color schemes for light and dark mode</string>
+    <string name="settings_color_scheme_light_title">Terminal color scheme (light)</string>
+    <string name="settings_color_scheme_dark_title">Terminal color scheme (dark)</string>
+    <string name="settings_color_scheme_light_dialog_title">Terminal color scheme — light</string>
+    <string name="settings_color_scheme_dark_dialog_title">Terminal color scheme — dark</string>
     <string name="settings_toolbar_title">Keyboard toolbar</string>
     <string name="settings_toolbar_subtitle">Configure toolbar keys and layout</string>
     <string name="settings_search_button_title">Search button</string>

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpScreen.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.ui.text.font.FontFamily
@@ -199,6 +200,9 @@ fun SftpScreen(
     val previewIsRemote by viewModel.previewIsRemote.collectAsState()
     val editorFile by viewModel.editorFile.collectAsState()
     val editorSaving by viewModel.editorSaving.collectAsState()
+    // Push system light/dark to the VM so the auto-switch pref resolves correctly.
+    val systemIsDark = isSystemInDarkTheme()
+    LaunchedEffect(systemIsDark) { viewModel.setSystemIsDark(systemIsDark) }
     val termColorScheme by viewModel.terminalColorScheme.collectAsState()
     val editorOpen = editorFile !is SftpViewModel.EditorFileState.Closed
     LaunchedEffect(editorOpen) { onEditorOpenChanged(editorOpen) }

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
@@ -615,9 +615,29 @@ class SftpViewModel @Inject constructor(
     private val _editorSaving = MutableStateFlow(false)
     val editorSaving: StateFlow<Boolean> = _editorSaving.asStateFlow()
 
+    /**
+     * Pushed down by [SftpScreen] every time `isSystemInDarkTheme()`
+     * recomposes — the ViewModel can't read Compose state itself, but
+     * needs the value so [terminalColorScheme] resolves correctly when
+     * auto-switch is enabled.
+     */
+    private val systemIsDark = MutableStateFlow(true)
+
+    fun setSystemIsDark(isDark: Boolean) {
+        systemIsDark.value = isDark
+    }
+
+    /** Effective terminal colour scheme, respecting auto-switch. */
     val terminalColorScheme: StateFlow<UserPreferencesRepository.TerminalColorScheme> =
-        preferencesRepository.terminalColorScheme
-            .stateIn(viewModelScope, SharingStarted.Eagerly, UserPreferencesRepository.TerminalColorScheme.HAVEN)
+        kotlinx.coroutines.flow.combine(
+            preferencesRepository.terminalColorScheme,
+            preferencesRepository.terminalAutoSwitchScheme,
+            preferencesRepository.terminalLightColorScheme,
+            preferencesRepository.terminalDarkColorScheme,
+            systemIsDark,
+        ) { manual, autoSwitch, light, dark, isDark ->
+            if (autoSwitch) (if (isDark) dark else light) else manual
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, UserPreferencesRepository.TerminalColorScheme.HAVEN)
 
     private var editorEntry: SftpEntry? = null
 

--- a/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
+++ b/feature/sftp/src/main/kotlin/sh/haven/feature/sftp/SftpViewModel.kt
@@ -629,7 +629,7 @@ class SftpViewModel @Inject constructor(
 
     /** Effective terminal colour scheme, respecting auto-switch. */
     val terminalColorScheme: StateFlow<UserPreferencesRepository.TerminalColorScheme> =
-        kotlinx.coroutines.flow.combine(
+        combine(
             preferencesRepository.terminalColorScheme,
             preferencesRepository.terminalAutoSwitchScheme,
             preferencesRepository.terminalLightColorScheme,

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
@@ -214,6 +215,12 @@ fun TerminalScreen(
     val activeTabIndex by viewModel.activeTabIndex.collectAsState()
     val ctrlActive by viewModel.ctrlActive.collectAsState()
     val altActive by viewModel.altActive.collectAsState()
+    // Push the live system light/dark mode to the ViewModel so its
+    // [terminalColorScheme] flow can resolve the auto-switch pref correctly.
+    // Must run before collecting the flow so the first emission reflects
+    // the current system theme rather than the StateFlow's `true` default.
+    val systemIsDark = isSystemInDarkTheme()
+    LaunchedEffect(systemIsDark) { viewModel.setSystemIsDark(systemIsDark) }
     val colorScheme by viewModel.terminalColorScheme.collectAsState()
     val navigateToConnections by viewModel.navigateToConnections.collectAsState()
     val newTabSessionPicker by viewModel.newTabSessionPicker.collectAsState()

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalScreen.kt
@@ -925,10 +925,16 @@ fun TerminalScreen(
                         // MATERIAL_YOU: pulled from MaterialTheme above and
                         // re-applied whenever the system theme shifts (light /
                         // dark / wallpaper change), so the terminal repaints.
+                        // Pushing the 16-colour ANSI palette alongside the
+                        // defaults is what makes SGR-coloured prompts (the
+                        // dominant text on most screens) actually track the
+                        // scheme — defaults alone only cover unstyled cells.
                         val terminalFgArgb = terminalFg.toArgb()
                         val terminalBgArgb = terminalBg.toArgb()
-                        LaunchedEffect(terminalFgArgb, terminalBgArgb, activeTab.emulator) {
-                            activeTab.emulator?.setDefaultColors(
+                        val ansiPalette = remember(activeTabScheme) { activeTabScheme.ansiPaletteArgb() }
+                        LaunchedEffect(terminalFgArgb, terminalBgArgb, ansiPalette, activeTab.emulator) {
+                            activeTab.emulator?.applyColorScheme(
+                                ansiPalette,
                                 terminalFgArgb,
                                 terminalBgArgb,
                             )
@@ -936,7 +942,8 @@ fun TerminalScreen(
 
                         // Force terminal redraw on resume from background
                         androidx.lifecycle.compose.LifecycleResumeEffect(activeTab.emulator) {
-                            activeTab.emulator?.setDefaultColors(
+                            activeTab.emulator?.applyColorScheme(
+                                ansiPalette,
                                 terminalFgArgb,
                                 terminalBgArgb,
                             )

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -493,7 +493,7 @@ class TerminalViewModel @Inject constructor(
      * [UserPreferencesRepository.terminalColorScheme] pref.
      */
     val terminalColorScheme: StateFlow<UserPreferencesRepository.TerminalColorScheme> =
-        kotlinx.coroutines.flow.combine(
+        combine(
             preferencesRepository.terminalColorScheme,
             preferencesRepository.terminalAutoSwitchScheme,
             preferencesRepository.terminalLightColorScheme,

--- a/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
+++ b/feature/terminal/src/main/kotlin/sh/haven/feature/terminal/TerminalViewModel.kt
@@ -245,11 +245,12 @@ data class TerminalTab(
     val resize: (Int, Int) -> Unit,
     val close: () -> Unit,
     /** Effective terminal colour scheme for this tab — the profile's
-     *  override (#144) or the user's global preference at the time the
-     *  tab was created. The screen reads this for the surrounding
-     *  surface so it matches the emulator's bg/fg. */
-    val colorScheme: UserPreferencesRepository.TerminalColorScheme =
-        UserPreferencesRepository.TerminalColorScheme.HAVEN,
+     *  override (#144) when set, or null to follow the live global
+     *  preference. The screen resolves null tabs to the global scheme
+     *  (which itself respects the system-driven auto-switch toggle) so
+     *  that flipping the system between light and dark mode repaints
+     *  every tab that doesn't have an explicit override. */
+    val colorScheme: UserPreferencesRepository.TerminalColorScheme? = null,
 )
 
 /** VNC connection info for the active terminal's host. */
@@ -472,13 +473,39 @@ class TerminalViewModel @Inject constructor(
         return recorder
     }
 
+    /**
+     * Pushed down by [TerminalScreen] every time `isSystemInDarkTheme()`
+     * recomposes — the ViewModel can't read Compose state itself, but
+     * needs the value so [effectiveGlobalScheme] resolves correctly when
+     * auto-switch is enabled.
+     */
+    private val systemIsDark = MutableStateFlow(true)
+
+    /** Called from the screen on every recomposition that observes the system theme. */
+    fun setSystemIsDark(isDark: Boolean) {
+        systemIsDark.value = isDark
+    }
+
+    /**
+     * Live global terminal colour scheme — respects the auto-switch toggle:
+     * when enabled, follows the system light/dark mode (via [systemIsDark])
+     * by picking the light or dark pref; otherwise returns the manual
+     * [UserPreferencesRepository.terminalColorScheme] pref.
+     */
     val terminalColorScheme: StateFlow<UserPreferencesRepository.TerminalColorScheme> =
-        preferencesRepository.terminalColorScheme
-            .stateIn(
-                viewModelScope,
-                SharingStarted.WhileSubscribed(5000),
-                UserPreferencesRepository.TerminalColorScheme.HAVEN,
-            )
+        kotlinx.coroutines.flow.combine(
+            preferencesRepository.terminalColorScheme,
+            preferencesRepository.terminalAutoSwitchScheme,
+            preferencesRepository.terminalLightColorScheme,
+            preferencesRepository.terminalDarkColorScheme,
+            systemIsDark,
+        ) { manual, autoSwitch, light, dark, isDark ->
+            if (autoSwitch) (if (isDark) dark else light) else manual
+        }.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            UserPreferencesRepository.TerminalColorScheme.HAVEN,
+        )
 
     /**
      * Scrollback ring size for newly created emulators (#151). Read at
@@ -494,20 +521,32 @@ class TerminalViewModel @Inject constructor(
             )
 
     /**
-     * Resolve the effective colour scheme for a tab built off [profile].
-     * Per-profile override (#144) wins; a missing profile, null override
-     * or unrecognised name all fall through to the global preference.
+     * Resolve the per-tab colour scheme for a tab built off [profile].
+     * Returns the profile's override (#144) when set, or null to mean
+     * "use the live global scheme" — the screen resolves null at
+     * render time so auto-switch and manual changes both propagate
+     * without us having to mutate existing tabs.
      */
     private fun effectiveColorScheme(
         profile: sh.haven.core.data.db.entities.ConnectionProfile?,
-    ): UserPreferencesRepository.TerminalColorScheme {
-        val override = profile?.terminalColorScheme?.let { name ->
+    ): UserPreferencesRepository.TerminalColorScheme? {
+        return profile?.terminalColorScheme?.let { name ->
             runCatching {
                 UserPreferencesRepository.TerminalColorScheme.valueOf(name)
             }.getOrNull()
         }
-        return override ?: terminalColorScheme.value
     }
+
+    /**
+     * Pick the scheme used to seed a brand-new emulator's default fg/bg.
+     * Override wins; otherwise the current effective global is used so
+     * the very first frame matches the surrounding chrome. The screen
+     * replaces this via [TerminalEmulator.setDefaultColors] on the next
+     * recomposition anyway, so any drift after construction is benign.
+     */
+    private fun initialEmulatorScheme(
+        override: UserPreferencesRepository.TerminalColorScheme?,
+    ): UserPreferencesRepository.TerminalColorScheme = override ?: terminalColorScheme.value
 
     private val _tabs = MutableStateFlow<List<TerminalTab>>(emptyList())
     val tabs: StateFlow<List<TerminalTab>> = _tabs.asStateFlow()
@@ -954,11 +993,12 @@ class TerminalViewModel @Inject constructor(
             val coalescer = InputCoalescer { data -> termSession.sendToSsh(data) }
             val sshProfile = runBlocking(Dispatchers.IO) { connectionRepository.getById(session.profileId) }
             val scheme = effectiveColorScheme(sshProfile)
+            val initialScheme = initialEmulatorScheme(scheme)
             emulator = TerminalEmulatorFactory.create(
                 initialRows = 24,
                 initialCols = 80,
-                defaultForeground = Color(scheme.foreground),
-                defaultBackground = Color(scheme.background),
+                defaultForeground = Color(initialScheme.foreground),
+                defaultBackground = Color(initialScheme.background),
                 enableAltScreen = sshProfile?.disableAltScreen != true && sshProfile?.sessionManager != "screen",
                 onKeyboardInput = { data -> coalescer.send(applyModifiers(data)) },
                 onResize = { dims ->
@@ -1046,11 +1086,12 @@ class TerminalViewModel @Inject constructor(
             val rnsCoalescer = InputCoalescer { data -> rnsSession.sendInput(data) }
             val rnsProfile = runBlocking(Dispatchers.IO) { connectionRepository.getById(session.profileId) }
             val rnsScheme = effectiveColorScheme(rnsProfile)
+            val rnsInitialScheme = initialEmulatorScheme(rnsScheme)
             emulator = TerminalEmulatorFactory.create(
                 initialRows = 24,
                 initialCols = 80,
-                defaultForeground = Color(rnsScheme.foreground),
-                defaultBackground = Color(rnsScheme.background),
+                defaultForeground = Color(rnsInitialScheme.foreground),
+                defaultBackground = Color(rnsInitialScheme.background),
                 enableAltScreen = rnsProfile?.disableAltScreen != true && rnsProfile?.sessionManager != "screen",
                 onKeyboardInput = { data -> rnsCoalescer.send(applyModifiers(data)) },
                 onResize = { dims ->
@@ -1149,12 +1190,13 @@ class TerminalViewModel @Inject constructor(
 
             val moshCoalescer = InputCoalescer { data -> moshSession.sendInput(data) }
             val moshScheme = effectiveColorScheme(moshProfile)
+            val moshInitialScheme = initialEmulatorScheme(moshScheme)
             emulator = TerminalEmulatorFactory.create(
                 initialRows = 24,
                 initialCols = 80,
-                defaultForeground = Color(moshScheme.foreground),
+                defaultForeground = Color(moshInitialScheme.foreground),
                 enableAltScreen = moshProfile?.disableAltScreen != true && moshProfile?.sessionManager != "screen",
-                defaultBackground = Color(moshScheme.background),
+                defaultBackground = Color(moshInitialScheme.background),
                 onKeyboardInput = { data -> moshCoalescer.send(applyModifiers(data)) },
                 onResize = { dims ->
                     Log.d(TAG, "MOSH onResize: ${dims.columns}x${dims.rows}")
@@ -1251,11 +1293,12 @@ class TerminalViewModel @Inject constructor(
 
             val etCoalescer = InputCoalescer { data -> etSession.sendInput(data) }
             val etScheme = effectiveColorScheme(etProfile)
+            val etInitialScheme = initialEmulatorScheme(etScheme)
             emulator = TerminalEmulatorFactory.create(
                 initialRows = 24,
                 initialCols = 80,
-                defaultForeground = Color(etScheme.foreground),
-                defaultBackground = Color(etScheme.background),
+                defaultForeground = Color(etInitialScheme.foreground),
+                defaultBackground = Color(etInitialScheme.background),
                 enableAltScreen = etProfile?.disableAltScreen != true && etProfile?.sessionManager != "screen",
                 onKeyboardInput = { data -> etCoalescer.send(applyModifiers(data)) },
                 onResize = { dims ->
@@ -1398,11 +1441,12 @@ class TerminalViewModel @Inject constructor(
             val localCoalescer = InputCoalescer { data -> localSession.sendInput(data) }
             val localProfile = runBlocking(Dispatchers.IO) { connectionRepository.getById(session.profileId) }
             val localScheme = effectiveColorScheme(localProfile)
+            val localInitialScheme = initialEmulatorScheme(localScheme)
             emulator = TerminalEmulatorFactory.create(
                 initialRows = 24,
                 initialCols = 80,
-                defaultForeground = Color(localScheme.foreground),
-                defaultBackground = Color(localScheme.background),
+                defaultForeground = Color(localInitialScheme.foreground),
+                defaultBackground = Color(localInitialScheme.background),
                 enableAltScreen = localProfile?.disableAltScreen != true && localProfile?.sessionManager != "screen",
                 onKeyboardInput = { data -> localCoalescer.send(applyModifiers(data)) },
                 onResize = { dims ->


### PR DESCRIPTION
## Summary

New Settings toggle: when enabled, the terminal scheme follows the system light/dark mode, with separate user-chosen schemes for each. Replaces the single fixed scheme with a (light, dark) pair while the toggle is on; flipping the system theme repaints every tab live without reopening. Per-profile scheme override (#144) still wins when set.

While wiring this up I found that `setDefaultColors` only updates libvterm's *default* fg/bg — so SGR-coloured prompts (the dominant text on most screens with zsh themes / starship / p10k) kept libvterm's stock palette and didn't track scheme changes. Added a 16-entry ANSI palette to each `TerminalColorScheme`; the screen now calls `applyColorScheme` so the surface and the prompt repaint together. Palettes are:

- **Canonical hand-curated** — Dracula, Solarized Dark, Solarized Light (used for `LIGHT`), Nord, Monokai, Gruvbox, Tokyo Night, QBasic (CGA).
- **Bespoke tuned to fg/bg** — Haven, Classic Green (monochromatic CRT), Amber, Pink, Lavender, Ocean.
- **Material You** — static Catppuccin Mocha fallback; doc-comment flags this as a candidate for later derivation from the live Material 3 tonal palettes.

The fix also covers the existing manual scheme switcher — that had the same gap, it just wasn't exercised often enough to be noticed.

## Test plan

- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew lintDebug`
- [x] `./gradlew :app:assembleArm64Debug`
- [x] Manual: toggle auto-switch on, flip system theme — surface and prompt both re-colour
- [x] Manual: manual scheme change also re-colours the prompt (regression check)
- [x] Manual: per-profile override (#144) still wins over auto-switch
- [x] Manual: each scheme renders a representative coloured prompt legibly

<details>
<summary>Screenshots:</summary>


**New Setting (Disabled):**
<img width="200" alt="photo_2026-05-19 07 06 24" src="https://github.com/user-attachments/assets/1d7aa58c-7611-4a8b-b4f8-e0c4edebe23a" />

**New Setting (Enabled):**

<img width="200" alt="photo_2026-05-19 07 06 29" src="https://github.com/user-attachments/assets/7234eac7-0c86-4105-8b26-6720f6cbaffe" />

**Theme Picker Popup for alt. theme:**

<img width="200" alt="photo_2026-05-19 07 06 32" src="https://github.com/user-attachments/assets/f8ba5a47-8d2b-4596-92b1-d9bb06cc94a8" />

</details>

<details>

<summary>Video Recording of switching in action:</summary>

**Auto-Switching OFF:**

https://github.com/user-attachments/assets/44d99f9f-3a51-44a1-8f1b-30fe53f32c4a

**Auto-Switching ON:**

https://github.com/user-attachments/assets/83beefe8-d7c5-4061-8c39-d4bed4bfbba2



</details>



